### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ About
    :target: https://pypi.python.org/pypi/anytemplate/
    :alt: [Python versions]
 
-.. .. image:: https://pypip.in/license/anytemplate/badge.png
+.. .. image:: https://img.shields.io/pypi/l/anytemplate.svg
    :target: https://pypi.python.org/pypi/anytemplate/
    :alt: [MIT License]
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20anytemplate))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `anytemplate`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.